### PR TITLE
refactor: 💡 changed user table name to systemuser

### DIFF
--- a/src/modules/system/user/entities/user.entity.ts
+++ b/src/modules/system/user/entities/user.entity.ts
@@ -22,7 +22,7 @@ import { UserRole } from '../../user-role/entities/user-role.entity';
 import { UserSettings } from './user-settings.entity';
 import { UserCoreProps } from 'src/core/entities/user-core-props.entity';
 
-@Entity('user', { schema: 'public' })
+@Entity('systemuser', { schema: 'public' })
 export class User extends UserCoreProps {
   static plural = 'users';
 


### PR DESCRIPTION
This commit will change the table name user to systemuser to avoid
conflict in the reserved keyword used in postgres