### PR TITLE
ci: 🎡 added support for slack updates for the TRAVIS CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,6 @@ notifications:
 
     on_failure: always
     on_success: always
+  
+  slack: hisptz:2UQgrRwNrI14ohefnnPyzms7
+


### PR DESCRIPTION
This commit will add support for sending the travis updates on slack