### PR TITLE
chore: 🤖 added support for dependabot for bumping dependencies

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,28 @@
+version: 1
+
+update_configs:
+  - package_manager: "ruby:bundler"
+    directory: "/common"
+    update_schedule: "live"
+    default_reviewers:
+    - greysteil
+
+  - package_manager: "php:composer"
+    directory: "/composer/helpers"
+    update_schedule: "live"
+
+  - package_manager: "elixir:hex"
+    directory: "/hex/helpers"
+    update_schedule: "live"
+
+  - package_manager: "javascript"
+    directory: "/npm_and_yarn/helpers"
+    update_schedule: "live"
+
+  - package_manager: "python"
+    directory: "/python/helpers"
+    update_schedule: "live"
+
+  - package_manager: "go:modules"
+    directory: "/go_modules/helpers"
+    update_schedule: "daily"


### PR DESCRIPTION
This commit will add support for dependabot for checking the latest
dependencies and update them accordingly